### PR TITLE
FEATURE: Added support to skip task execution on savepoint commits

### DIFF
--- a/djcelery_transactions/settings.py
+++ b/djcelery_transactions/settings.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+'''
+Created on Jan 8, 2015
+
+@author: jakob
+'''
+from django.conf import settings
+
+# Whether or not to execute tasks on savepoint commits
+EXEC_ON_SAVEPOINT = getattr(settings, 'DJCELERY_TRANSACTIONS_EXEC_ON_SAVEPOINT', True)

--- a/djcelery_transactions/transaction_signals.py
+++ b/djcelery_transactions/transaction_signals.py
@@ -39,7 +39,7 @@ class TransactionSignals(object):
     """A container for the transaction signals."""
 
     def __init__(self):
-        self.post_commit = Signal()
+        self.post_commit = Signal(providing_args=['sid'])
         self.post_rollback = Signal()
 
 
@@ -68,7 +68,7 @@ def __patched__exit__(self, exc_type, exc_value, traceback):
                 if sid is not None:
                     try:
                         connection.savepoint_commit(sid)
-                        transaction.signals.post_commit.send(None)
+                        transaction.signals.post_commit.send(None, sid=sid)
                     except DatabaseError:
                         try:
                             connection.savepoint_rollback(sid)
@@ -83,7 +83,7 @@ def __patched__exit__(self, exc_type, exc_value, traceback):
                 # Commit transaction
                 try:
                     connection.commit()
-                    transaction.signals.post_commit.send(None)
+                    transaction.signals.post_commit.send(None, sid=None)
                 except DatabaseError:
                     try:
                         connection.rollback()


### PR DESCRIPTION
This allows to only execute the task queue on non-savepoint commits if explicitly configured via:

``` python
DJCELERY_TRANSACTIONS_EXEC_ON_SAVEPOINT = False
```

in the settings.py
